### PR TITLE
Fix: use the port in get too

### DIFF
--- a/scp.js
+++ b/scp.js
@@ -34,6 +34,8 @@ scp.get = function (options, cb) {
   var command = [
     'scp',
     '-r',
+    '-P',
+    (options.port == undefined) ? '22' : options.port),
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];


### PR DESCRIPTION
The port options was not used in the "get" method.
