### PR TITLE
Add ssh option to not use shared connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "Ben Evans <ben@bensbit.co.uk>",
     "Gabriel Preston <gpreston@gmail.com>",
     "Joseph Silvestre <joseph.silvestre38@gmail.com>",
-    "appr <appr@appr.me>"
+    "appr <appr@appr.me>",
+    "Daniel Phatthanan <daniel@phatthanan.com>"
   ],
   "name": "scp",
   "description": "remote file copy wrapper",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/ecto/node-scp.git"

--- a/scp.js
+++ b/scp.js
@@ -15,6 +15,7 @@ scp.send = function (options, cb) {
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
+    '-o "ControlMaster no"', //callback is not fired if ssh sessions are shared
     options.file,
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.path,
   ];
@@ -36,6 +37,7 @@ scp.get = function (options, cb) {
     '-r',
     '-P',
     (options.port == undefined ? '22' : options.port),
+    '-o "ControlMaster no"', //callback is not fired if ssh sessions are shared
     (options.user == undefined ? '' : options.user+'@') + options.host + ':' + options.file,
     options.path
   ];


### PR DESCRIPTION
I am using persistent SSH connections.

Part of my .ssh/config:

```
ControlMaster auto
ControlPath  /Users/udondan/.ssh/tmp/%h_%p_%r
ControlPersist 3600
```

For some reason, this prevents the exec() callback from being executed. The file downloads/uploads fine, just the cb is not run. 

Adding the ssh option **-o "ControlMaster no"** solves this issue. It's a pity, as shared ssh connections are meant to prevent re-connecting. The same ssh session would be used for multiple up- and downloads from/to the same host.
